### PR TITLE
build(docker): use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM ubuntu:22.04
+FROM frolvlad/alpine-glibc:glibc-2.30
 
 WORKDIR /bun
-
-RUN apt-get update
-RUN apt-get install curl unzip -y
-RUN curl --fail --location --progress-bar --output "/bun/bun.zip" "https://github.com/Jarred-Sumner/bun/releases/download/bun-v0.1.1/bun-linux-x64.zip"
-RUN unzip -d /bun -q -o "/bun/bun.zip"
-RUN mv /bun/bun-linux-x64/bun /usr/local/bin/bun
-RUN chmod 777 /usr/local/bin/bun
+RUN apk --no-cache add curl bash libstdc++ ca-certificates && \
+    curl -fsSL -o "/bun/bun.zip" "https://github.com/Jarred-Sumner/bun/releases/download/bun-v0.1.2/bun-linux-x64.zip" && \
+    unzip -d /bun -q -o "/bun/bun.zip" && \
+    mv /bun/bun-linux-x64/bun /usr/local/bin/bun && \
+    chmod 777 /usr/local/bin/bun && \
+    rm "/bun/bun.zip" && \
+    apk del curl bash
 
 WORKDIR /app
-RUN addgroup --gid 101 --system appuser && adduser --uid 101 --system appuser
-RUN chown -R 101:101 /app && chmod -R g+w /app
+RUN addgroup --gid 101 --system appuser && adduser --uid 101 --system appuser && chown -R 101:101 /app && chmod -R g+w /app
 USER appuser
 COPY . ./
 
-CMD bun run server.js
+CMD ["bun", "run", "server.js"]


### PR DESCRIPTION
I refactored Dockerfile to use alpine as base image which reduce the image size from 387MB to 98.7MB and also the build time

New image works locally & on railway

Maybe we should use [bun's docker image](https://hub.docker.com/r/jarredsumner/bun) how ever the version control wouldn't be ideal as only tag edge is available for now